### PR TITLE
X-Correlation-ID instead of Correlation-ID

### DIFF
--- a/input/fsh/profiles/CapabilityStatement.fsh
+++ b/input/fsh/profiles/CapabilityStatement.fsh
@@ -20,7 +20,7 @@ Usage: #definition
 * contact.telecom.system = #url
 
 * extension[HnzApiSpecBuilderExtension].extension[globalHeaders].extension[+].url = Canonical(HnzCustomHeadersExtension)
-* extension[HnzApiSpecBuilderExtension].extension[globalHeaders].extension[=].extension[key].valueString = "Correlation-Id"
+* extension[HnzApiSpecBuilderExtension].extension[globalHeaders].extension[=].extension[key].valueString = "X-Correlation-Id"
 * extension[HnzApiSpecBuilderExtension].extension[globalHeaders].extension[=].extension[value].valueUri = "https://raw.githubusercontent.com/tewhatuora/schemas/main/fhir-definitions-oas/id-definition.json"
 * extension[HnzApiSpecBuilderExtension].extension[globalHeaders].extension[=].extension[required].valueBoolean = true
 * extension[HnzApiSpecBuilderExtension].extension[licenseURL].valueUri = "https://example.license.org"

--- a/input/images/MockPlus-Smoke-Test.postman_collection
+++ b/input/images/MockPlus-Smoke-Test.postman_collection
@@ -301,7 +301,7 @@
 								"type": "text"
 							},
 							{
-								"key": "x-correlation-id",
+								"key": "X-Correlation-Id",
 								"value": "XDRTREFYTEDFS-1",
 								"type": "text"
 							}


### PR DESCRIPTION
Ingress and Mulesoft logging to Datadog, setting `@correlation_id:` requires X-Correlation-ID